### PR TITLE
feat: finalize type rewrite

### DIFF
--- a/src/evaluation.py
+++ b/src/evaluation.py
@@ -6,16 +6,11 @@ from src.postprocessing import postprocess, TASK_STRATEGIES, RESPONSE_STRATEGIES
 from funcy_chain import Chain
 from dacite import from_dict
 from itertools import starmap
-from typing import Callable
 
 
 def evaluate_one_task(task: BenchmarkTask, result: str) -> bool:
     ground_truth = postprocess(task.signature, TASK_STRATEGIES)
     result = postprocess(result, RESPONSE_STRATEGIES)
-    # print(ground_truth)
-    # print(result)
-    # print(ground_truth == result)
-    # print('\n')
     return ground_truth == result
 
 

--- a/src/postprocessing.py
+++ b/src/postprocessing.py
@@ -1,10 +1,6 @@
 import re
 from functools import reduce
 from typing import Callable
-from openai import OpenAI
-import os
-import openai
-import tiktoken
 
 
 def char_list_to_str(text: str) -> str:

--- a/tests/test_rewrite.py
+++ b/tests/test_rewrite.py
@@ -1,13 +1,15 @@
 from dacite import from_dict
 from src.common import BenchmarkTask
+from typing import Callable
 from src.type_rewrite import (
     preprocess,
     manual_change,
     convert_upper_to_lower,
     remove_string_content,
-    postprocess,
+    reverse_process,
     rewrite,
 )
+from src.postprocessing import postprocess
 
 
 def test_rewrite():
@@ -43,11 +45,14 @@ def test_rewrite():
     )
 
     # process the raw code
-    combined_code = preprocess(combined_code)
-    combined_code = manual_change(combined_code)
-    combined_code = convert_upper_to_lower(combined_code)
-    combined_code = remove_string_content(combined_code)
-    combined_code = postprocess(combined_code)
+    process_strategy: list[Callable[[str], str]] = [
+        preprocess,
+        manual_change,
+        convert_upper_to_lower,
+        remove_string_content,
+        reverse_process,
+    ]
+    combined_code = postprocess(combined_code, process_strategy)
 
     rewritten_code = rewrite(combined_code)
 


### PR DESCRIPTION
The previous rewrite also modified infix operators. This version, however, allows infix operators to remain unchanged. Additionally, it prevents rewriting certain keywords like "otherwise" while still rewriting terms like "Nothing." The updated benchmark and test results have been manually reviewed to validate these changes.